### PR TITLE
Indi/pennies/wet pennies 1

### DIFF
--- a/GodotProject/scenes/adspunjerer_3d.tscn
+++ b/GodotProject/scenes/adspunjerer_3d.tscn
@@ -8,8 +8,6 @@ height = 3.0
 radius = 3.0
 
 [node name="Adspunjerer3D" type="CharacterBody3D"]
-collision_layer = 2
-collision_mask = 3
 axis_lock_linear_y = true
 axis_lock_angular_x = true
 axis_lock_angular_z = true

--- a/GodotProject/scenes/coins/penny_3d.tscn
+++ b/GodotProject/scenes/coins/penny_3d.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://e7kc0ybm3f6w"]
+[gd_scene load_steps=10 format=3 uid="uid://e7kc0ybm3f6w"]
 
 [ext_resource type="Script" path="res://scripts/penny_3d.gd" id="1_5juj5"]
 [ext_resource type="Texture2D" uid="uid://cvfg4fv20riaq" path="res://assets/sprites/coins/1p/1p_obverse_new.png" id="2_6gl1j"]
@@ -14,6 +14,10 @@ rough = true
 margin = 0.0
 height = 0.2
 radius = 1.015
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_rlgvo"]
+transparency = 1
+albedo_color = Color(0, 0.4, 1, 0.364706)
 
 [node name="Penny3D" type="RigidBody3D"]
 collision_layer = 4
@@ -50,3 +54,9 @@ texture = ExtResource("5_7sn2l")
 [node name="RimOld" type="Sprite3D" parent="RimSpriteContainer"]
 sorting_offset = -0.003
 texture = ExtResource("6_rfhdw")
+
+[node name="wet_viz_cyl" type="CSGCylinder3D" parent="."]
+radius = 1.3
+height = 0.324
+sides = 64
+material = SubResource("StandardMaterial3D_rlgvo")

--- a/GodotProject/scenes/coins/penny_3d.tscn
+++ b/GodotProject/scenes/coins/penny_3d.tscn
@@ -20,8 +20,8 @@ transparency = 1
 albedo_color = Color(0, 0.4, 1, 0.364706)
 
 [node name="Penny3D" type="RigidBody3D"]
-collision_layer = 4
-collision_mask = 7
+collision_layer = 2
+collision_mask = 3
 axis_lock_linear_y = true
 axis_lock_angular_x = true
 axis_lock_angular_z = true

--- a/GodotProject/scenes/coins/penny_3d.tscn
+++ b/GodotProject/scenes/coins/penny_3d.tscn
@@ -20,8 +20,6 @@ transparency = 1
 albedo_color = Color(0, 0.4, 1, 0.364706)
 
 [node name="Penny3D" type="RigidBody3D"]
-collision_layer = 2
-collision_mask = 3
 axis_lock_linear_y = true
 axis_lock_angular_x = true
 axis_lock_angular_z = true

--- a/GodotProject/scenes/game_3d.tscn
+++ b/GodotProject/scenes/game_3d.tscn
@@ -1,15 +1,10 @@
-[gd_scene load_steps=8 format=3 uid="uid://blpc6pvpxt0j3"]
+[gd_scene load_steps=6 format=3 uid="uid://blpc6pvpxt0j3"]
 
 [ext_resource type="PackedScene" uid="uid://dcpc5ql4ujd1v" path="res://scenes/adspunjerer_3d.tscn" id="1_covkf"]
 [ext_resource type="Script" path="res://scripts/camera_pivot_3d.gd" id="1_mf45f"]
 [ext_resource type="Script" path="res://scripts/adspunjerer_3d.gd" id="2_c34sh"]
 [ext_resource type="Script" path="res://scripts/penny_spawner_3d.gd" id="4_knyrr"]
 [ext_resource type="Script" path="res://scripts/txt3d_reacts_to_input.gd" id="4_sfwvd"]
-
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_ty12r"]
-rough = true
-
-[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_rd785"]
 
 [node name="Game3D" type="Node3D"]
 
@@ -41,12 +36,6 @@ Your goal is to acquire as many SPUNJ points as possible, to [[[[REDACTED]]]]"
 font_size = 200
 autowrap_mode = 2
 width = 4000.0
-
-[node name="StaticBody3D" type="StaticBody3D" parent="."]
-physics_material_override = SubResource("PhysicsMaterial_ty12r")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
-shape = SubResource("WorldBoundaryShape3D_rd785")
 
 [node name="PennySpawner3D" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 30)

--- a/GodotProject/scenes/game_3d.tscn
+++ b/GodotProject/scenes/game_3d.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://blpc6pvpxt0j3"]
+[gd_scene load_steps=7 format=3 uid="uid://blpc6pvpxt0j3"]
 
 [ext_resource type="PackedScene" uid="uid://dcpc5ql4ujd1v" path="res://scenes/adspunjerer_3d.tscn" id="1_covkf"]
 [ext_resource type="Script" path="res://scripts/camera_pivot_3d.gd" id="1_mf45f"]
 [ext_resource type="Script" path="res://scripts/adspunjerer_3d.gd" id="2_c34sh"]
 [ext_resource type="Script" path="res://scripts/penny_spawner_3d.gd" id="4_knyrr"]
 [ext_resource type="Script" path="res://scripts/txt3d_reacts_to_input.gd" id="4_sfwvd"]
+[ext_resource type="Script" path="res://scenes/txt_wetness_display.gd" id="5_2r5om"]
 
 [node name="Game3D" type="Node3D"]
 
@@ -28,6 +29,15 @@ autowrap_mode = 1
 width = 4000.0
 script = ExtResource("4_sfwvd")
 
+[node name="wetness_box" type="Label3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 18.1612)
+pixel_size = 0.01
+text = "Wetness: 0"
+font_size = 200
+autowrap_mode = 1
+width = 4000.0
+script = ExtResource("5_2r5om")
+
 [node name="txt3d_you_are_adventurer" type="Label3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -15.8)
 pixel_size = 0.01
@@ -40,3 +50,5 @@ width = 4000.0
 [node name="PennySpawner3D" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 30)
 script = ExtResource("4_knyrr")
+
+[connection signal="new_wetness" from="Adspunjerer3D" to="wetness_box" method="set_wetness_text"]

--- a/GodotProject/scenes/txt_wetness_display.gd
+++ b/GodotProject/scenes/txt_wetness_display.gd
@@ -1,0 +1,5 @@
+extends Label3D
+
+
+func set_wetness_text(wetness: float) -> void:
+	text = "Wetness: " + str(float(wetness))

--- a/GodotProject/scripts/adspunjerer_3d.gd
+++ b/GodotProject/scripts/adspunjerer_3d.gd
@@ -12,6 +12,8 @@ var spunjelity: float = 3.5  # todo :: tuning
 var spunjelity_bonus_roll_n: int = 20  # it's like DnD?
 var wetness: float = 0.0
 
+signal new_wetness
+
 func get_spunj():
 	return spunjelity + rng.randi_range(1, spunjelity_bonus_roll_n)
 
@@ -50,5 +52,4 @@ func _physics_process(delta: float) -> void:
 			var did_spong = collider.sponge()  # todo :: probs want to use signals?
 			if did_spong:
 				wetness += 1
-				print(wetness)
-				
+				emit_signal("new_wetness", wetness)

--- a/GodotProject/scripts/adspunjerer_3d.gd
+++ b/GodotProject/scripts/adspunjerer_3d.gd
@@ -43,6 +43,6 @@ func _physics_process(delta: float) -> void:
 	for i in range(get_slide_collision_count()):
 		var collider = get_slide_collision(i).get_collider()
 		if collider is Penny3D:
-			var dp = collider.position - position;
-			dp.z = 0;
-			collider.apply_central_impulse(dp * 1000);
+			var dp = collider.position - position
+			dp.z = 0
+			collider.apply_central_impulse(dp * 1000)

--- a/GodotProject/scripts/adspunjerer_3d.gd
+++ b/GodotProject/scripts/adspunjerer_3d.gd
@@ -40,3 +40,9 @@ func _process(delta: float) -> void:
 
 func _physics_process(delta: float) -> void:
 	move_and_slide()
+	for i in range(get_slide_collision_count()):
+		var collider = get_slide_collision(i).get_collider()
+		if collider is Penny3D:
+			var dp = collider.position - position;
+			dp.z = 0;
+			collider.apply_central_impulse(dp * 1000);

--- a/GodotProject/scripts/adspunjerer_3d.gd
+++ b/GodotProject/scripts/adspunjerer_3d.gd
@@ -10,6 +10,7 @@ var current_hp: int = TOTAL_HIT_POINTS
 var base_attack_power: float = 5.0
 var spunjelity: float = 3.5  # todo :: tuning
 var spunjelity_bonus_roll_n: int = 20  # it's like DnD?
+var wetness: float = 0.0
 
 func get_spunj():
 	return spunjelity + rng.randi_range(1, spunjelity_bonus_roll_n)
@@ -46,4 +47,8 @@ func _physics_process(delta: float) -> void:
 			var dp = collider.position - position
 			dp.z = 0
 			collider.apply_central_impulse(dp * 1000)
-			collider.sponge()  # todo :: probs want to use signals?
+			var did_spong = collider.sponge()  # todo :: probs want to use signals?
+			if did_spong:
+				wetness += 1
+				print(wetness)
+				

--- a/GodotProject/scripts/adspunjerer_3d.gd
+++ b/GodotProject/scripts/adspunjerer_3d.gd
@@ -46,3 +46,4 @@ func _physics_process(delta: float) -> void:
 			var dp = collider.position - position
 			dp.z = 0
 			collider.apply_central_impulse(dp * 1000)
+			collider.sponge()  # todo :: probs want to use signals?

--- a/GodotProject/scripts/penny_3d.gd
+++ b/GodotProject/scripts/penny_3d.gd
@@ -2,6 +2,8 @@ class_name Penny3D extends RigidBody3D
 
 var rng = RandomNumberGenerator.new()
 
+var is_wet: bool = false
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	rng.randomize()

--- a/GodotProject/scripts/penny_3d.gd
+++ b/GodotProject/scripts/penny_3d.gd
@@ -24,8 +24,3 @@ func _ready() -> void:
 	var oldness = rng.randf()
 	sprite_face_new.modulate.a = oldness
 	sprite_rim_new.modulate.a = oldness
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	pass

--- a/GodotProject/scripts/penny_3d.gd
+++ b/GodotProject/scripts/penny_3d.gd
@@ -4,16 +4,16 @@ var rng = RandomNumberGenerator.new()
 
 var is_wet: bool = false
 
+@onready var sprite_container_face : Node3D = get_node("FaceSpriteContainer")
+@onready var sprite_face_new : Sprite3D = sprite_container_face.get_node("FaceNew")
+@onready var sprite_face_old : Sprite3D = sprite_container_face.get_node("FaceOld")
+@onready var sprite_container_rim : Node3D = get_node("RimSpriteContainer")
+@onready var sprite_rim_new : Sprite3D = sprite_container_rim.get_node("RimNew")
+@onready var sprite_rim_old : Sprite3D = sprite_container_rim.get_node("RimOld")
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	rng.randomize()
-	
-	var sprite_container_face : Node3D = get_node("FaceSpriteContainer")
-	var sprite_face_new : Sprite3D = sprite_container_face.get_node("FaceNew")
-	var sprite_face_old : Sprite3D = sprite_container_face.get_node("FaceOld")
-	var sprite_container_rim : Node3D = get_node("RimSpriteContainer")
-	var sprite_rim_new : Sprite3D = sprite_container_rim.get_node("RimNew")
-	var sprite_rim_old : Sprite3D = sprite_container_rim.get_node("RimOld")
 	
 	if rng.randf() < 0.5:
 		sprite_face_new.texture = load("res://assets/sprites/coins/1p/1p_reverse_new.png")

--- a/GodotProject/scripts/penny_3d.gd
+++ b/GodotProject/scripts/penny_3d.gd
@@ -2,7 +2,7 @@ class_name Penny3D extends RigidBody3D
 
 var rng = RandomNumberGenerator.new()
 
-var is_wet: bool = false
+var is_wet: bool = true
 
 @onready var sprite_container_face : Node3D = get_node("FaceSpriteContainer")
 @onready var sprite_face_new : Sprite3D = sprite_container_face.get_node("FaceNew")
@@ -27,6 +27,9 @@ func _ready() -> void:
 	sprite_rim_new.modulate.a = oldness
 
 
-func sponge() -> void:
+func sponge() -> bool:
+	if not is_wet:
+		return false
 	is_wet = false
 	wet_viz_cyl.visible = false
+	return true

--- a/GodotProject/scripts/penny_3d.gd
+++ b/GodotProject/scripts/penny_3d.gd
@@ -10,6 +10,7 @@ var is_wet: bool = false
 @onready var sprite_container_rim : Node3D = get_node("RimSpriteContainer")
 @onready var sprite_rim_new : Sprite3D = sprite_container_rim.get_node("RimNew")
 @onready var sprite_rim_old : Sprite3D = sprite_container_rim.get_node("RimOld")
+@onready var wet_viz_cyl : Node3D = get_node("wet_viz_cyl")
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -24,3 +25,8 @@ func _ready() -> void:
 	var oldness = rng.randf()
 	sprite_face_new.modulate.a = oldness
 	sprite_rim_new.modulate.a = oldness
+
+
+func sponge() -> void:
+	is_wet = false
+	wet_viz_cyl.visible = false


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/312b3b98-af83-413e-8a73-0e4d42255a5a)

add wetness and de-wetting pennies.

I had to change the physics of how this works to implement this. collisions were previously not symmetric (in terms of collision layer), so I think what was happening was the player clipped inside the pennies and this launched them away. honestly that was decent physics, but seems to make doing collision logic in code for any other effects a bit annoying. instead I've emulated roughly this with a collider.apply_central_impulse(dp * 1000), which is a total magic number, but seems to give somewhat similar behaviour.